### PR TITLE
feat(forum): send thread context inline to /forum/chat/v2, remove MCP dependency

### DIFF
--- a/classes/ai_service.php
+++ b/classes/ai_service.php
@@ -39,7 +39,7 @@ class ai_service {
         $payload = utils::normalize_payload($payload);
 
         $client = new ai_services_api();
-        $response = $client->request('POST', '/forum/chat', $payload);
+        $response = $client->request('POST', '/forum/chat/v2', $payload);
 
         return [
             'reply' => $response['reply'] ?? null,

--- a/classes/task/process_ai_discussion.php
+++ b/classes/task/process_ai_discussion.php
@@ -103,9 +103,14 @@ class process_ai_discussion extends adhoc_task {
                 'forum' => $forum->name,
                 'discussion' => $discussion->name,
                 'discussion_id' => $discussionid,
+                'postid' => $post->id,
+                // Thread context sent inline — no MCP needed.
+                'thread_history' => utils::build_thread_context(
+                    (int)$discussionid,
+                    (int)$post->id,
+                ),
                 // Only consider configured auto-grader in automatic approval mode.
                 'userid' => (string)($effectivegraderid ?? 2),
-                'postid' => $post->id,
                 'prompt' => $replymessage,
                 'allow_followup_question' => $allowfollowupquestion,
                 'grading_enabled' => $gradingenabled,

--- a/classes/task/process_ai_post.php
+++ b/classes/task/process_ai_post.php
@@ -119,6 +119,11 @@ class process_ai_post extends adhoc_task {
                     'subject' => $post->subject,
                     'message' => $postmessage,
                 ],
+                // Thread context sent inline — no MCP needed.
+                'thread_history' => utils::build_thread_context(
+                    (int)$discussion->id,
+                    (int)$post->id,
+                ),
                 // Only consider configured auto-grader in automatic approval mode.
                 'userid' => (string)($effectivegraderid ?? 2),
                 'prompt' => $replymessage,

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -258,6 +258,69 @@ class utils {
     }
 
     /**
+     * Builds the thread context for a given post within a discussion.
+     *
+     * Collects all ancestor posts (from root to direct parent), and
+     * returns them as a structured array so the Python service can
+     * decide how to format the prompt, without needing MCP.
+     *
+     * Each entry contains the post id, chronological order, author
+     * full name, and cleaned message text.
+     *
+     * @param int $discussionid Discussion ID.
+     * @param int $postid Current post ID.
+     * @return array List of thread entries with id, order, author, message.
+     */
+    public static function build_thread_context(
+        int $discussionid,
+        int $postid,
+    ): array {
+        global $DB;
+
+        // Ancestors are returned [parent, grandparent, …, root].
+        // Reverse to get chronological order [root, …, grandparent, parent].
+        $ancestorids = array_reverse(
+            self::get_thread_ancestor_post_ids($discussionid, $postid),
+        );
+
+        $threadentries = [];
+        $order = 1;
+        foreach ($ancestorids as $ancestorid) {
+            $ancestor = $DB->get_record(
+                'forum_posts',
+                ['id' => $ancestorid, 'discussion' => $discussionid],
+                'id,userid,message,messageformat',
+                IGNORE_MISSING,
+            );
+            if (!$ancestor) {
+                continue;
+            }
+            $author = $DB->get_record(
+                'user',
+                ['id' => $ancestor->userid],
+                'id,firstname,lastname',
+                IGNORE_MISSING,
+            );
+            $authorname = $author ? fullname($author) : (string)$ancestor->userid;
+
+            $cleaned = trim(strip_tags($ancestor->message));
+            if ($cleaned === '') {
+                continue;
+            }
+
+            $threadentries[] = [
+                'id' => (int)$ancestor->id,
+                'order' => $order,
+                'author' => $authorname,
+                'message' => $cleaned,
+            ];
+            $order++;
+        }
+
+        return $threadentries;
+    }
+
+    /**
      * Builds the structured payload for the AI forum evaluation service.
      *
      * This method gathers all necessary data related to a user's participation

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_forum_ai';
-$plugin->release = '1.0.5';
-$plugin->version = 2026051400;
+$plugin->release = '1.0.6';
+$plugin->version = 2026052700;
 $plugin->requires = 2024100700;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [405, 501];


### PR DESCRIPTION
**Compatibility note:** This version is compatible **from Moodle 4.5 to Moodle 5.1**.

## Added
- **New `POST /forum/chat/v2` endpoint with required inline thread context.**  
  The AI service now provides a versioned endpoint (`/chat/v2`) that requires `thread_history` as a structured array. Old plugins continue using `/chat` (v1) with MCP fallback unchanged. This allows gradual migration without breaking existing installations.
- **Structured thread context sent inline from plugin.**  
  `build_thread_context()` in `utils.php` collects all ancestor posts (root → direct parent) and returns them as an array of `{id, order, author, message}` entries, so the Python service can format the LLM prompt without needing MCP.

## Changed
- **`build_thread_context()` simplified to return entries only.**  
  The function no longer fetches the current post separately nor returns `current_message`. It now returns just the entries array, saving one database query per request.
- **`process_ai_post.php` and `process_ai_discussion.php` send inline payload.**  
  Both tasks now send `thread_history` as a structured array directly in the JSON payload. The `current_message` field was removed from the payload.
- **`ai_service.php` calls versioned endpoint.**  
  The service URL was changed from `/forum/chat` to `/forum/chat/v2` to explicitly target the MCP-free endpoint. The `/forum/grade` endpoint remains unchanged.
- **Version bumped to `1.0.6`.**

## Fixed
- **`current_message` no longer overrides `post.message` losing `@@PLUGINFILE@@` resolution.**  
  In the previous approach, `current_message` (which uses only `strip_tags()` without `format_text()`) was overriding `post.message` (which resolves embedded file URLs via `format_text()`). This caused the LLM to see `@@PLUGINFILE@@/image.png` instead of resolved URLs. The Python service now only uses `current_message` when `post` is absent (discussion handler), preserving `format_text()` processing in the post handler.
- **Removed redundant `current_message` field from plugin payload.**  
  The field was duplicated with `post.message` for the post handler and introduced a risk of inconsistency. The discussion handler case is handled directly by the Python service.